### PR TITLE
Adapt code to the new API of hsyslog version 5

### DIFF
--- a/logsink.cabal
+++ b/logsink.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.11.0.
+-- This file has been generated from package.yaml by hpack version 0.17.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -30,7 +30,7 @@ library
   build-depends:
       base == 4.*
     , logging-facade
-    , hsyslog
+    , hsyslog >= 5
     , time
   exposed-modules:
       System.Logging.LogSink.Config
@@ -45,12 +45,12 @@ test-suite spec
   main-is: Spec.hs
   hs-source-dirs:
       src
-    , test
+      test
   ghc-options: -Wall
   build-depends:
       base == 4.*
     , logging-facade
-    , hsyslog
+    , hsyslog >= 5
     , time
     , hspec == 2.*
   other-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,7 @@ ghc-options: -Wall
 dependencies:
   - base == 4.*
   - logging-facade
-  - hsyslog
+  - hsyslog >= 5
   - time
 
 source-dirs:


### PR DESCRIPTION
Note that previous versions work only with `hsyslog < 3`.